### PR TITLE
Fix docker image tag

### DIFF
--- a/decred-dcrdex/docker-compose.yml
+++ b/decred-dcrdex/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       APP_PORT: 5758
   
   web:
-    image: decred/dcrdex:release-v0.6.3@sha256:a3b81b170eb5d4c3d291d342ef5997dcb5425292a874e05b6098ab3d04f0bed5
+    image: decred/dcrdex:v0.6.3@sha256:a3b81b170eb5d4c3d291d342ef5997dcb5425292a874e05b6098ab3d04f0bed5
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/dex/.dexc


### PR DESCRIPTION
The `release-v0.6.3` image tag is invalid, the correct format is `v0.6.3`.