### PR TITLE
Fix docker image tag and hash

### DIFF
--- a/decred-dcrdex/docker-compose.yml
+++ b/decred-dcrdex/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       APP_PORT: 5758
   
   web:
-    image: decred/dcrdex:release-v0.6.3@sha256:a3b81b170eb5d4c3d291d342ef5997dcb5425292a874e05b6098ab3d04f0bed5
+    image: decred/dcrdex:v0.6.3@sha256:b063466bd9a7262c383a763e22fe91dd20bed824fa31a18fe557eadb6ce5c500
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/dex/.dexc


### PR DESCRIPTION
The `release-v0.6.3` image tag is invalid, the correct format is `v0.6.3`.  This has changed in 0.6.1 and I overlooked since then.

The pinned hash was also incorrect, it was referring to the ARM image, not the multiarch hash, preventing it from running on x86 hardware.

### To confirm that the file refers to the same image

The multiarch hash is not shown on Docker Hub. It can be obtained from the `buildx` workflow output (but the `v0.6.3` log expired), or using https://github.com/estesp/manifest-tool:

```
docker run mplatform/manifest-tool inspect  decred/dcrdex:v0.6.3
```
This outputs:
```
Name:   decred/dcrdex:v0.6.3 (Type: application/vnd.oci.image.index.v1+json)
Digest: sha256:b063466bd9a7262c383a763e22fe91dd20bed824fa31a18fe557eadb6ce5c500     <-- current value
 * Contains 4 manifest references (2 images, 2 attestations):
[1]     Type: application/vnd.oci.image.manifest.v1+json
[1]   Digest: sha256:a3b81b170eb5d4c3d291d342ef5997dcb5425292a874e05b6098ab3d04f0bed5    <- previous value
[1]   Length: 1435
[1] Platform:
[1]    -      OS: linux
[1]    -    Arch: arm64
```

please confirm the current and previous values.



